### PR TITLE
Update create_instance to take refs

### DIFF
--- a/src/vulkan/safe/functions.rs
+++ b/src/vulkan/safe/functions.rs
@@ -11,18 +11,18 @@ use super::device_items::device_create_info::DeviceCreateInfo;
 use super::device_items::physical_device::PhysicalDevice;
 
 pub(crate) fn create_instance(
-    create_info: Option<VkInstanceCreateInfo>, 
-    allocator: Option<VkAllocationCallbacks>, 
+    create_info: Option<&VkInstanceCreateInfo>, 
+    allocator: Option<&mut VkAllocationCallbacks>, 
 ) -> Result<VkInstance, i32> {
     unsafe {
         let mut instance: VkInstance = zeroed();
         let result = vkCreateInstance(
             match create_info {
-                Some(create_info) => &create_info as *const _,
+                Some(create_info) => create_info as *const _,
                 None => ptr::null(),
             },
             match allocator {
-                Some(mut allocator) => &mut allocator as *mut _,
+                Some(allocator) => allocator as *mut _,
                 None => ptr::null_mut(),
             },
             &mut instance,


### PR DESCRIPTION
It only uses refs anyway, so we should be fine having it take refs in instead of consuming the values.

This is a partial fix only, usages will still need to be fixed. I expect the callsites of this function will need to bind the values being passed in to their outer scope and then pass the references in.

Should help prevent use-after-free of the refs being used here.